### PR TITLE
fix try_files for assets served from PHP on Octane

### DIFF
--- a/src/nginx/sites-available/default-octane
+++ b/src/nginx/sites-available/default-octane
@@ -57,7 +57,7 @@ server {
         access_log off;
         log_not_found off;
         # Pass to PHP to ensure PHP apps can handle routes that end in these filetypes
-        try_files $uri /index.php?$query_string;
+        try_files $uri @octane;
     }
 
     location ~* \.(?:svgz?|ttf|ttc|otf|eot|woff2?)$ {


### PR DESCRIPTION
Hi!

This PR tries to fix a problem where serving assets using PHP with Octane is not redirecting properly.

I recently tried to make a new project using Laravel and Filament. On a freshly installed Laravel app served using Octane, the assets for the Filament app are not loaded properly, resulting in 404s. The assets for Filament are [loaded dynamically](https://github.com/filamentphp/filament/blob/0a5f6c7be0d7a19744d9468eb06d7cae7f7f4f92/packages/admin/routes/web.php#LL14C22-L14C22), and the nginx configuration for Octane is not redirecting the request properly.

This PR tries to fix this problem by replacing `/index.php?$query_string` with `@octane` in the try_files section. 

Thank you!