### PR TITLE
Include a flag to turn allow_url_fopen off/on

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ The following environment variables can be set at run-time or when extending thi
 | PHP_MAX_EXECUTION_TIME | php setting max_execution_time       | 90            |
 | PHP_POST_MAX_SIZE | php setting post_max_size            | 100M          |
 | PHP_UPLOAD_MAX_FILE_SIZE | php setting upload_max_file_size     | 100M          |
-| PHP_ALLOW_URL_FOPEN | php setting allow_url_fopen     | 0          |
+| PHP_ALLOW_URL_FOPEN | php setting allow_url_fopen     | 1          |

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ The following environment variables can be set at run-time or when extending thi
 | PHP_MAX_EXECUTION_TIME | php setting max_execution_time       | 90            |
 | PHP_POST_MAX_SIZE | php setting post_max_size            | 100M          |
 | PHP_UPLOAD_MAX_FILE_SIZE | php setting upload_max_file_size     | 100M          |
+| PHP_ALLOW_URL_FOPEN | php setting allow_url_fopen     | 0          |

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ The following environment variables can be set at run-time or when extending thi
 | PHP_MAX_EXECUTION_TIME | php setting max_execution_time       | 90            |
 | PHP_POST_MAX_SIZE | php setting post_max_size            | 100M          |
 | PHP_UPLOAD_MAX_FILE_SIZE | php setting upload_max_file_size     | 100M          |
-| PHP_ALLOW_URL_FOPEN | php setting allow_url_fopen     | 1          |
+| PHP_ALLOW_URL_FOPEN | php setting allow_url_fopen     | Off          |

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PHP_MAX_EXECUTION_TIME=90 \
     PHP_POST_MAX_SIZE=100M \
     PHP_UPLOAD_MAX_FILE_SIZE=100M \
-    PHP_ALLOW_URL_FOPEN=1
+    PHP_ALLOW_URL_FOPEN=Off
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY php/ondrej_ubuntu_php.gpg /etc/apt/trusted.gpg.d/ondrej_ubuntu_php.gpg

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -18,7 +18,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PHP_MEMORY_LIMIT=256M \
     PHP_MAX_EXECUTION_TIME=90 \
     PHP_POST_MAX_SIZE=100M \
-    PHP_UPLOAD_MAX_FILE_SIZE=100M
+    PHP_UPLOAD_MAX_FILE_SIZE=100M \
+    PHP_ALLOW_URL_FOPEN=1
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY php/ondrej_ubuntu_php.gpg /etc/apt/trusted.gpg.d/ondrej_ubuntu_php.gpg

--- a/src/Dockerfile-unit
+++ b/src/Dockerfile-unit
@@ -47,7 +47,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PHP_MAX_EXECUTION_TIME=90 \
     PHP_POST_MAX_SIZE=100M \
     PHP_UPLOAD_MAX_FILE_SIZE=100M \ 
-    PHP_ALLOW_URL_FOPEN=1
+    PHP_ALLOW_URL_FOPEN=Off
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY php/ondrej_ubuntu_php.gpg /etc/apt/trusted.gpg.d/ondrej_ubuntu_php.gpg

--- a/src/Dockerfile-unit
+++ b/src/Dockerfile-unit
@@ -46,7 +46,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PHP_MEMORY_LIMIT=256M \
     PHP_MAX_EXECUTION_TIME=90 \
     PHP_POST_MAX_SIZE=100M \
-    PHP_UPLOAD_MAX_FILE_SIZE=100M
+    PHP_UPLOAD_MAX_FILE_SIZE=100M \ 
+    PHP_ALLOW_URL_FOPEN=1
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 COPY php/ondrej_ubuntu_php.gpg /etc/apt/trusted.gpg.d/ondrej_ubuntu_php.gpg

--- a/src/fpm/pool.d/www.conf
+++ b/src/fpm/pool.d/www.conf
@@ -523,3 +523,6 @@ php_admin_value[max_execution_time] = ${PHP_MAX_EXECUTION_TIME}
 ; Upload settings
 php_admin_value[post_max_size] = ${PHP_POST_MAX_SIZE}
 php_admin_value[upload_max_filesize] = ${PHP_UPLOAD_MAX_FILE_SIZE}
+
+; Allow remote file access settings
+php_admin_value[allow_url_fopen] = ${PHP_ALLOW_URL_FOPEN}


### PR DESCRIPTION
**WHAT AND WHY:**
Include a flag for turning on/off the allow_url_fopen configuration directive. 
This will make it easier for users extending the laravel-docker image to turn it off/on. i.e:
This was requested to be turned off for the Dockerfile generated by dockerfile-laravel, for improving security of apps deployed with it(This may allow remote script execution!).

**HOW:**
Include another php_admin_value in the www.config file that sets the value for allow_url_fopen, and set the default value in Dockerfile and Dockerfile-unit templates. The default value would be "Off" to remove the security risk. 

**Helpful discussion**
Which would be a better default value, 1 or 0? I'm afraid that this setting might override any user-setting config file, i.e. htaccess, php.ini file. So in that thought, it would be more secure to use 0 as default value, as selecting 1( even though it's the default value set in the php.ini file ) would be re-introducing a security risk the user has already turned off. But! I'm going to try and check if it indeed overrides any user config file