### PR TITLE
Revise github workflow to run once a week, on Fridays

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,7 +1,7 @@
 name: Build Base Images
 on:
   schedule:
-    - cron: "0 */72 * * *"
+    - cron: "0 0 * * 5"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**What and Why:**
Update the github workflow schedule to run once a week.

There are two main reasons:
1. **Need to revise the current crontab expression.** For context, the current entry is:

```
"0 */72 * * *"
```
The above should translate to "every 72 hours". However, this isn't the current behavior; instead, the workflow runs in a daily manner. This could be attributed to the reason that the [2nd field in a crontab entry](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07:~:text=Minute%20%5B0%2C59%5D-,Hour,-%5B0%2C23%5D)( hour ) only has a maximum number of **23**, and since the entry added is **72**, this doesn't fall under the scope of the field.

2. Reduce the number of times the repository is built into an image and pushed to dockerhub.

**How:**
1. Update the crontab expression to use the 5th field to express it to run every 5th of the week: Friday